### PR TITLE
Prevent data mutation bug

### DIFF
--- a/pkg/pb/label.go
+++ b/pkg/pb/label.go
@@ -52,6 +52,21 @@ func MakeLabels(args ...string) *LabelSet {
 	return &out
 }
 
+func (ls *LabelSet) Add(name, value string) *LabelSet {
+	dup := &LabelSet{}
+
+	dup.Labels = append(dup.Labels, ls.Labels...)
+
+	dup.Labels = append(dup.Labels, &Label{
+		Name:  name,
+		Value: value,
+	})
+
+	dup.Finalize()
+
+	return dup
+}
+
 // Call if manually creating a LabelSet once it's filled
 func (ls *LabelSet) Finalize() {
 	sort.Sort(ls)

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -139,12 +139,7 @@ func (f *Frontend) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if deploySpecific {
-		target.Labels = append(target.Labels, &pb.Label{
-			Name:  ":deployment",
-			Value: deployId,
-		})
-
-		target.Finalize()
+		target = target.Add(":deployment", deployId)
 	}
 
 	// we should always have limits, but in the case that something is using an old API and


### PR DESCRIPTION
The old version was manipulating the LabelSet that is stored between
requests if a deployment URL is used, which results in the next request
not working because the deployment label will be duplicated in the Set.

The situation resolves itself when the LabelLinks are downloaded again
but is basically broken for a minute at a time. Let's not break it.