### PR TITLE
add terms/policy links to landing page

### DIFF
--- a/internal/httpassets/static/index.html
+++ b/internal/httpassets/static/index.html
@@ -51,7 +51,7 @@
           >.
         </p>
         <p>
-          The Hashicorp-managed instance of this service at https://waypoint.run
+          The HashiCorp-managed instance of this service at https://waypoint.run
           is subject to Waypoint&rsquo;s
           <a href="https://www.waypointproject.io/terms">Terms of Use</a>,
           <a href="https://www.waypointproject.io/security">Security</a>, and

--- a/internal/httpassets/static/index.html
+++ b/internal/httpassets/static/index.html
@@ -50,6 +50,13 @@
           <a href="https://discuss.hashicorp.com">HashiCorp Discussion Forums</a
           >.
         </p>
+        <p>
+          The Hashicorp-managed instance of this service at https://waypoint.run
+          is subject to Waypoint&rsquo;s
+          <a href="https://www.waypointproject.io/terms">Terms of Use</a>,
+          <a href="https://www.waypointproject.io/security">Security</a>, and
+          <a href="https://hashicorp.com/privacy">Privacy</a> policies.
+        </p>
         <p><small>&copy; 2020 HashiCorp, Inc.</small></p>
       </footer>
     </div>


### PR DESCRIPTION
This adds required terms/policy links to the https://waypoint.run landing page, same as in the footer at https://waypointproject.io.