### PR TITLE
pkg/control: use a pool of zstd writers to reuse encoding buffers

### DIFF
--- a/kubernetes/control.yml
+++ b/kubernetes/control.yml
@@ -29,9 +29,17 @@ spec:
               "namespace": "control",
               "metrics": [
                 {"go_goroutines":"goroutines"},
-                {"go_memstats_heap_sys_bytes":"heap_size"},
+                {"go_memstats_heap_inuse_bytes":"heap_size"},
+                {"go_memstats_heap_idle_bytes":"idle_heap_size"},
                 {"control_total_messages":"total.messages"},
-                {"control_total_bytes":"total.bytes"}
+                {"control_total_bytes":"total.bytes"},
+                {"control_service_add":"service.add"},
+                {"control_service_remove":"service.remove"},
+                {"control_account_create":"account.create"},
+                {"control_hub_connect":"hub.connect"},
+                {"control_hub_disconnect":"hub.disconnect"},
+                {"control_hubs_fetch_config_time":"hub.fetch_config"},
+                {"control_routing_update_time":"routing.update"}
               ]
             }
           ]
@@ -81,10 +89,13 @@ spec:
 
       containers:
       - name: control
-        image: quay.io/hashicorp/horizon:E-1
+        image: quay.io/hashicorp/horizon:185-71049c5
         args:
           - control
         env:
+          - name: GODEBUG
+            value: madvdontneed=1
+
           - name: AWS_REGION
             value: us-west-2
 
@@ -169,6 +180,14 @@ spec:
           - name: ASNDB
             value: /geoip/asn.mmdb
 
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+
+          - name: CONSUL_HTTP_ADDR
+            value: "$(HOST_IP):8500"
+
         ports:
           - name: tls
             containerPort: 443
@@ -180,7 +199,8 @@ spec:
             path: /healthz
             port: monitoring
           initialDelaySeconds: 30
-          periodSeconds: 3
+          periodSeconds: 20
+          timeoutSeconds: 5
 
         volumeMounts:
           - mountPath: /geoip

--- a/pkg/control/s3.go
+++ b/pkg/control/s3.go
@@ -46,7 +46,7 @@ func (s *Server) calculateAccountRouting(ctx context.Context, gdb *sql.DB, accou
 		default:
 		}
 
-		rows, err := gdb.Query("SELECT id, hub_id, service_id, labels, type FROM services WHERE account_id = $1 AND id > $2 LIMIT 1000", key, lastId)
+		rows, err := gdb.QueryContext(ctx, "SELECT id, hub_id, service_id, labels, type FROM services WHERE account_id = $1 AND id > $2 LIMIT 1000", key, lastId)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
After 3 hours of heavy use, we're seeing Go hold onto about 5GB of "idle" heap. Pretty sure this is because in that 3 hours, there has been 170GB of allocation, with the bulk coming from these zstd writers.

<img width="498" alt="pprof001 svg 2020-10-28 16-23-14" src="https://user-images.githubusercontent.com/7/97507195-e6be6600-1939-11eb-8f45-4c6eca1a4a4a.png">
