### PR TITLE
cmd/hzn: shutdown idle connections after 2 minutes to try to tame goroutine leak

### DIFF
--- a/cmd/hzn/main.go
+++ b/cmd/hzn/main.go
@@ -365,8 +365,9 @@ func (c *controlServer) Run(args []string) int {
 	lcfg.Certificates = []tls.Certificate{tlsCert}
 
 	hs := &http.Server{
-		TLSConfig: &lcfg,
-		Addr:      ":" + port,
+		TLSConfig:   &lcfg,
+		Addr:        ":" + port,
+		IdleTimeout: 2 * time.Minute,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.ProtoMajor == 2 &&
 				strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {


### PR DESCRIPTION
We're seeing climbing goroutines in control that look like this:

```
216 @ 0x43c285 0x4349db 0x46c215 0x4f68e5 0x4f7925 0x4f7903 0x5d3b6f 0x5e7f0e 0x6483c2 0x489071 0x648613 0x645435 0x64b6ff 0x64b70a 0x70ff8d 0x5868a5 0x5875fd 0x587834 0x68c0cc 0x70a12a 0x70a159 0x71141a 0x715ae5 0x471c61
#	0x46c214	internal/poll.runtime_pollWait+0x54		/usr/local/go/src/runtime/netpoll.go:220
#	0x4f68e4	internal/poll.(*pollDesc).wait+0x44		/usr/local/go/src/internal/poll/fd_poll_runtime.go:87
#	0x4f7924	internal/poll.(*pollDesc).waitRead+0x1a4	/usr/local/go/src/internal/poll/fd_poll_runtime.go:92
#	0x4f7902	internal/poll.(*FD).Read+0x182			/usr/local/go/src/internal/poll/fd_unix.go:159
#	0x5d3b6e	net.(*netFD).Read+0x4e				/usr/local/go/src/net/fd_posix.go:55
#	0x5e7f0d	net.(*conn).Read+0x8d				/usr/local/go/src/net/net.go:182
#	0x6483c1	crypto/tls.(*atLeastReader).Read+0x61		/usr/local/go/src/crypto/tls/conn.go:779
#	0x489070	bytes.(*Buffer).ReadFrom+0xb0			/usr/local/go/src/bytes/buffer.go:204
#	0x648612	crypto/tls.(*Conn).readFromUntil+0xf2		/usr/local/go/src/crypto/tls/conn.go:801
#	0x645434	crypto/tls.(*Conn).readRecordOrCCS+0x114	/usr/local/go/src/crypto/tls/conn.go:608
#	0x64b6fe	crypto/tls.(*Conn).readRecord+0x15e		/usr/local/go/src/crypto/tls/conn.go:576
#	0x64b709	crypto/tls.(*Conn).Read+0x169			/usr/local/go/src/crypto/tls/conn.go:1252
#	0x70ff8c	net/http.(*connReader).Read+0x1ac		/usr/local/go/src/net/http/server.go:798
#	0x5868a4	bufio.(*Reader).fill+0x104			/usr/local/go/src/bufio/bufio.go:101
#	0x5875fc	bufio.(*Reader).ReadSlice+0x3c			/usr/local/go/src/bufio/bufio.go:360
#	0x587833	bufio.(*Reader).ReadLine+0x33			/usr/local/go/src/bufio/bufio.go:389
#	0x68c0cb	net/textproto.(*Reader).readLineSlice+0x6b	/usr/local/go/src/net/textproto/reader.go:58
#	0x70a129	net/textproto.(*Reader).ReadLine+0xa9		/usr/local/go/src/net/textproto/reader.go:39
#	0x70a158	net/http.readRequest+0xd8			/usr/local/go/src/net/http/request.go:1012
#	0x711419	net/http.(*conn).readRequest+0x199		/usr/local/go/src/net/http/server.go:984
#	0x715ae4	net/http.(*conn).serve+0x704			/usr/local/go/src/net/http/server.go:1851
```

Here we've got 216 goroutines hanging out waiting for another request. Hopefully setting the idletimeout will tame this. If not, we'll dig in further.