### PR TITLE
Prevent hubs from accidentally routing requests back on eachother

### DIFF
--- a/pkg/connect/connect.go
+++ b/pkg/connect/connect.go
@@ -143,7 +143,7 @@ func (s *Session) ConnecToAccountService(acc *pb.Account, labels *pb.LabelSet) (
 	return &Conn{serviceId: ack.ServiceId, fr: fr2, fw: fw2}, nil
 }
 
-func (s *Session) ConnecToService(labels *pb.LabelSet) (*Conn, error) {
+func (s *Session) ConnectToService(labels *pb.LabelSet) (*Conn, error) {
 	return s.ConnecToAccountService(nil, labels)
 }
 

--- a/pkg/hub/hub_test.go
+++ b/pkg/hub/hub_test.go
@@ -297,7 +297,7 @@ func TestHub(t *testing.T) {
 
 				L.Info("connecting to service")
 
-				c, err := sess.ConnecToService(pb.ParseLabelSet("service=echo"))
+				c, err := sess.ConnectToService(pb.ParseLabelSet("service=echo"))
 				require.NoError(t, err)
 
 				assert.Equal(t, serviceId, c.ServiceId())

--- a/pkg/hub/incoming.go
+++ b/pkg/hub/incoming.go
@@ -353,7 +353,7 @@ func (h *Hub) forwardToTarget(
 	// passing the service id we calculated here. The advantage is that things
 	// might have changed and the target has a better target (which would result
 	// in multiple relays).
-	conn, err := session.ConnecToService(req.Target)
+	conn, err := session.ConnectToService(req.Target)
 	if err != nil {
 		return err
 	}

--- a/pkg/hub/incoming.go
+++ b/pkg/hub/incoming.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"strconv"
@@ -71,6 +72,20 @@ func (h *Hub) handleAgentStream(ctx context.Context, ai *agentConn, stream *yamu
 
 	routes := calc.Services()
 
+	possible := len(routes)
+
+	if len(routes) == 0 {
+		var resp pb.Response
+		resp.Error = fmt.Sprintf(
+			"route calculation found no possible routes. account=%s target=%s",
+			wctx.Account().SpecString(),
+			req.Target.SpecString(),
+		)
+
+		wctx.WriteMarshal(255, &resp)
+		return
+	}
+
 	for len(routes) > 0 {
 		var target *pb.ServiceRoute
 
@@ -101,7 +116,12 @@ func (h *Hub) handleAgentStream(ctx context.Context, ai *agentConn, stream *yamu
 	}
 
 	var resp pb.Response
-	resp.Error = "no routes available to target"
+	resp.Error = fmt.Sprintf(
+		"no routes available to target: possible=%d account=%s target=%s",
+		possible,
+		wctx.Account().SpecString(),
+		req.Target.SpecString(),
+	)
 	wctx.WriteMarshal(255, &resp)
 }
 


### PR DESCRIPTION
The work to load balance incoming requests was a bit to eager and caused a hub that had a service locally to route the request back to another hub, even if that second hub had actually requests the connection in the first place.

This is because horizon has very primitive routing and didn't consider the local route to a service a priority. This fixes that.