### PR TITLE
Fix bufio crash by not using ulit.Monotonic (which isn't concurrency safe)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = hashicorp.jfrog.io/docker/docker/dockerfile:experimental
 
-FROM hashicorp.jfrog.io/docker/golang:1.14-alpine AS builder
+FROM hashicorp.jfrog.io/docker/golang:1.15-alpine AS builder
 
 RUN apk add --no-cache git gcc libc-dev
 

--- a/pkg/pb/ulid.go
+++ b/pkg/pb/ulid.go
@@ -1,23 +1,13 @@
 package pb
 
 import (
-	"io"
-	"os"
+	"crypto/rand"
 	"time"
 
 	"github.com/oklog/ulid"
 )
 
-var mrand io.Reader
-
-func init() {
-	f, err := os.Open("/dev/urandom")
-	if err != nil {
-		panic(err)
-	}
-
-	mrand = ulid.Monotonic(f, 1)
-}
+var mrand = rand.Reader
 
 func NewULID() *ULID {
 	id := ulid.MustNew(ulid.Now(), mrand)


### PR DESCRIPTION
Story time:

The crash in question is: 

```
2020/11/06 21:47:24 http: panic serving 44.231.191.201:49454: runtime error: slice bounds out of range [:8192] with capacity 4096
goroutine 1910828 [running]:
net/http.(*conn).serve.func1(0xc000268820)
        /usr/local/go/src/net/http/server.go:1800 +0x139
panic(0x1ba95a0, 0xc001fd22a0)
        /usr/local/go/src/runtime/panic.go:975 +0x3e3
bufio.(*Reader).Read(0xc000351080, 0xc001678106, 0xa, 0xa, 0xc000854520, 0xc000299570, 0x100000001599d65)
        /usr/local/go/src/bufio/bufio.go:237 +0x3c9
io.ReadAtLeast(0x2053b80, 0xc000351080, 0xc001678106, 0xa, 0xa, 0xa, 0xc000299520, 0xc000299528, 0x40ecb8)
        /usr/local/go/src/io/io.go:310 +0x87
io.ReadFull(...)
        /usr/local/go/src/io/io.go:329
github.com/oklog/ulid.(*monotonic).MonotonicRead(0xc0003d7b80, 0x1759f8746c4, 0xc001678106, 0xa, 0xa, 0x323e609ee54e, 0x2ebe3a0)
        /go/pkg/mod/github.com/oklog/ulid@v1.3.1/ulid.go:518 +0x84
github.com/oklog/ulid.New(0x1759f8746c4, 0x20552a0, 0xc0003d7b80, 0xc002130280, 0x40, 0x40, 0x7f1e68ab9101)
```

I kept thinking it was a bug in bufio or a bug in rand.Reader which is was actually much more obvious: bufio is not concurrency safe. The crash is caused by 2 goroutines doing a Read from the underlying Reader and both of them being `b.w += n`, setting the write value to 8192.

ulid.Monotonic was just a nicety to make the ULIDs in the same timestamp lexically sorted, but we don't really care about that because of the limited view of that anyway. So we'll ditch it and just using `rand.Reader` as the entropy source directly.