### PR TITLE
pkg/control: Pick up new hub image tag dynamically

### DIFF
--- a/pkg/control/server.go
+++ b/pkg/control/server.go
@@ -173,7 +173,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	)
 
 	if cfg.HubImageTag != "" && cfg.HubImageTag[0] == '@' {
-		L.Info("fetected hub image tag is a file, monitoring it for changes")
+		L.Info("detected hub image tag is a file, monitoring it for changes")
 
 		hubImageFile = cfg.HubImageTag[1:]
 


### PR DESCRIPTION
This allows the HubImageTag value to be a file that is polled for
changes. This allows the kubernetes deployments to point the HubImageTag
value to a dynamically updated file from the configmap.

When we revise the hub/control connection model, we'll allow the hub to
push down a signal that the hubs need to pickup new config as well.