### PR TITLE
pkg/hub: disable background reordering for now

### DIFF
--- a/pkg/discovery/client.go
+++ b/pkg/discovery/client.go
@@ -115,7 +115,11 @@ func (c *Client) Refresh(ctx context.Context) error {
 
 	c.results = ch
 
-	go c.backgroundRefresh(ctx)
+	// TODO(evanphx) There is a bug caused by setting latest to nil and THEN
+	// populating the search results. Because the search is just reordered
+	// the servers based on latency, just skip it for now and use our initial
+	// results.
+	// go c.backgroundRefresh(ctx)
 
 	return nil
 }


### PR DESCRIPTION
There is a bug in the backgroundRefresh code, where it resets the latest set to nothing and then repopulates it. If this happens when the instance is having network issues, then the background detection code will not be able to reach any hubs and end up wiping out their records entirely.

Because the backgroundRefresh is just used to detect if hubs are lost and reorder them based on latency, we're going to just disable this code for now. Once the hub figures out the hubs that are available on launch, it will use those for the whole time it runs.