### PR TITLE
pkg/web, httpassets: include the error reason on the error page

### DIFF
--- a/internal/httpassets/static/error.html
+++ b/internal/httpassets/static/error.html
@@ -27,6 +27,9 @@
           <a href="https://www.waypointproject.io/docs/url">documentation</a>
           for help with Waypoint.
         </p>
+        <p>
+          Error reason: %s
+        </p>
       </section>
       <footer>
         <a href="https://hashicorp.com" class="hashi">


### PR DESCRIPTION
This also make sure the endpoint header is on the error pages.