### PR TITLE
Fix missing calls to lz4.Writer.Close and yamux.Stream.Close

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -450,7 +450,11 @@ func (a *Agent) handleStream(ctx context.Context, L hclog.Logger, session *yamux
 
 	if useLZ4 {
 		r = lz4.NewReader(stream)
-		w = lz4.NewWriter(stream)
+
+		lzw := lz4.NewWriter(stream)
+		defer lzw.Close()
+
+		w = lzw
 	}
 
 	fr, err := wire.NewFramingReader(r)

--- a/pkg/hub/hub.go
+++ b/pkg/hub/hub.go
@@ -562,11 +562,15 @@ func (h *Hub) handleConn(ctx context.Context, conn net.Conn) {
 		var (
 			r io.Reader = stream
 			w io.Writer = stream
+
+			lzw *lz4.Writer
 		)
 
 		if ai.useLZ4 {
 			r = lz4.NewReader(stream)
-			w = lz4.NewWriter(stream)
+
+			lzw = lz4.NewWriter(stream)
+			w = lzw
 		}
 
 		fr, err := wire.NewFramingReader(r)
@@ -586,6 +590,9 @@ func (h *Hub) handleConn(ctx context.Context, conn net.Conn) {
 		defer fw.Recycle()
 
 		wctx := wire.NewContext(ai.token.Account(), fr, fw)
+		if lzw != nil {
+			wctx = wire.WithCloser(wctx, lzw.Close)
+		}
 
 		h.L.Trace("accepted yamux session", "id", stream.StreamID())
 


### PR DESCRIPTION
The lz4.Writer.Close will make sure lz4's buffer pool is refilled and reduces it's allocation load significantly.

The yamux.Stream.Close makes it so the other side of the stream properly cleans itself up and deref's the stream from the session, which allows it to release the memory the stream is using.