### PR TITLE
pkg/testutils: DeleteBucket ignores bucket that doesn't exist

### DIFF
--- a/pkg/control/client_test.go
+++ b/pkg/control/client_test.go
@@ -41,10 +41,11 @@ func TestClient(t *testing.T) {
 	vc := testutils.SetupVault()
 	sess := testutils.AWSSession(t)
 
-	bucket := "hzntest-" + pb.NewULID().SpecString()
-	s3.New(sess).CreateBucket(&s3.CreateBucketInput{
+	bucket := "hzntest-" + strings.ToLower(pb.NewULID().SpecString())
+	_, err := s3.New(sess).CreateBucket(&s3.CreateBucketInput{
 		Bucket: aws.String(bucket),
 	})
+	require.NoError(t, err)
 
 	defer testutils.DeleteBucket(s3.New(sess), bucket)
 

--- a/pkg/control/server_test.go
+++ b/pkg/control/server_test.go
@@ -1,9 +1,10 @@
 package control
 
 import (
-	context "context"
+	"context"
 	"errors"
 	"io/ioutil"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,11 +65,11 @@ func TestServer(t *testing.T) {
 	vc := testutils.SetupVault()
 	sess := testutils.AWSSession(t)
 
-	bucket := "hzntest"
-
-	s3.New(sess).CreateBucket(&s3.CreateBucketInput{
+	bucket := "hzntest-" + strings.ToLower(pb.NewULID().SpecString())
+	_, err := s3.New(sess).CreateBucket(&s3.CreateBucketInput{
 		Bucket: aws.String(bucket),
 	})
+	require.NoError(t, err)
 
 	defer testutils.DeleteBucket(s3.New(sess), bucket)
 

--- a/pkg/testutils/central/dev.go
+++ b/pkg/testutils/central/dev.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -54,10 +55,11 @@ func Dev(t testing.T, f func(setup *DevSetup)) {
 		WithS3ForcePathStyle(true),
 	)
 
-	bucket := "hzntest-" + pb.NewULID().SpecString()
-	s3.New(sess).CreateBucket(&s3.CreateBucketInput{
+	bucket := strings.ToLower("hzntest-" + pb.NewULID().SpecString())
+	_, err := s3.New(sess).CreateBucket(&s3.CreateBucketInput{
 		Bucket: aws.String(bucket),
 	})
+	require.NoError(t, err)
 
 	defer testutils.DeleteBucket(s3.New(sess), bucket)
 

--- a/pkg/testutils/s3.go
+++ b/pkg/testutils/s3.go
@@ -1,6 +1,8 @@
 package testutils
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -27,6 +29,11 @@ func DeleteBucket(api *s3.S3, bucket string) {
 		})
 
 		if err != nil {
+			// Deleting a non-existent bucket is not a bug
+			if strings.Contains(err.Error(), "NoSuchBucket") {
+				break
+			}
+
 			panic(err)
 		}
 


### PR DESCRIPTION
It appears that localstack used to not error in this case and return an empty list, but they recently started returning this error instead. Our test helper that deleted test buckets didn't handle it properly and was failing tests.