### PR TITLE
feat: disable insecureSkipVerify on by default

### DIFF
--- a/cmd/hzn/main.go
+++ b/cmd/hzn/main.go
@@ -432,6 +432,9 @@ func (h *hubRunner) Run(args []string) int {
 		log.Fatal("missing TOKEN")
 	}
 
+	insecure := os.Getenv("INSECURE") == "1"
+	insecureSkipVerify := os.Getenv("INSECURE_SKIP_VERIFY") == "1"
+
 	addr := os.Getenv("CONTROL_ADDR")
 	if addr == "" {
 		log.Fatal("missing ADDR")
@@ -526,14 +529,16 @@ func (h *hubRunner) Run(args []string) int {
 	}
 
 	client, err := control.NewClient(ctx, control.ClientConfig{
-		Id:           id,
-		InstanceId:   instanceId,
-		Token:        token,
-		Version:      "test",
-		Addr:         addr,
-		WorkDir:      tmpdir,
-		K8Deployment: deployment,
-		FilterRoute:  filter,
+		Id:                 id,
+		InstanceId:         instanceId,
+		Token:              token,
+		Version:            "test",
+		Addr:               addr,
+		WorkDir:            tmpdir,
+		K8Deployment:       deployment,
+		FilterRoute:        filter,
+		Insecure:           insecure,
+		InsecureSkipVerify: insecureSkipVerify,
 	})
 
 	if deployment != "" {
@@ -893,14 +898,15 @@ func (h *devServer) RunHub(ctx context.Context, token, addr string, sess *sessio
 	gClient := pb.NewControlServicesClient(gcc)
 
 	client, err := control.NewClient(ctx, control.ClientConfig{
-		Id:       id,
-		Token:    token,
-		Version:  "test",
-		Client:   gClient,
-		WorkDir:  tmpdir,
-		Session:  sess,
-		S3Bucket: bucket,
-		Insecure: true,
+		Id:                 id,
+		Token:              token,
+		Version:            "test",
+		Client:             gClient,
+		WorkDir:            tmpdir,
+		Session:            sess,
+		S3Bucket:           bucket,
+		Insecure:           true,
+		InsecureSkipVerify: true,
 	})
 
 	defer client.Close(ctx)

--- a/cmd/hzn/main.go
+++ b/cmd/hzn/main.go
@@ -661,12 +661,16 @@ func (c *devServer) Run(args []string) int {
 		log.Fatal(err)
 	}
 
-	sess := session.New(aws.NewConfig().
+	sess, err := session.NewSession(aws.NewConfig().
 		WithEndpoint("http://localhost:4566").
 		WithRegion("us-east-1").
 		WithCredentials(credentials.NewStaticCredentials("hzn", "hzn", "hzn")).
 		WithS3ForcePathStyle(true),
 	)
+
+	if err != nil {
+		log.Fatalf("unable to connect to S3: %v", err)
+	}
 
 	bucket := os.Getenv("S3_BUCKET")
 	if bucket == "" {
@@ -674,9 +678,12 @@ func (c *devServer) Run(args []string) int {
 		L.Info("using hzn-dev as the S3 bucket")
 	}
 
-	s3.New(sess).CreateBucket(&s3.CreateBucketInput{
+	_, err = s3.New(sess).CreateBucket(&s3.CreateBucketInput{
 		Bucket: aws.String(bucket),
 	})
+	if err != nil {
+		return 0
+	}
 
 	domain := os.Getenv("HUB_DOMAIN")
 	if domain == "" {

--- a/cmd/hznctl/main.go
+++ b/cmd/hznctl/main.go
@@ -70,6 +70,7 @@ func (h *hubTokenCreate) Run(args []string) int {
 
 	addr := fs.String("control-addr", "127.0.0.1:24001", "Address of control server")
 	insecure := fs.Bool("insecure", false, "Whether or not to secure the grpc connection")
+	insecureSkipVerify := fs.Bool("insecureSkipVerify", false, "Whether or not to disable SSL verification")
 	token := fs.String("token", "", "Token to authenticate with control server")
 
 	err := fs.Parse(args)
@@ -82,15 +83,7 @@ func (h *hubTokenCreate) Run(args []string) int {
 		grpc.WithDefaultCallOptions(grpc.UseCompressor(lz4.Name)),
 	}
 
-	if *insecure {
-		opts = append(opts, grpc.WithInsecure())
-	} else {
-		creds := credentials.NewTLS(&tls.Config{
-			InsecureSkipVerify: true,
-		})
-
-		opts = append(opts, grpc.WithTransportCredentials(creds))
-	}
+	opts = setTransport(opts, insecure, insecureSkipVerify)
 
 	gcc, err := grpc.Dial(*addr, opts...)
 	if err != nil {
@@ -126,6 +119,7 @@ func (h *mgmtTokenCreate) Run(args []string) int {
 
 	addr := fs.String("control-addr", "127.0.0.1:24001", "Address of control server")
 	insecure := fs.Bool("insecure", false, "Whether or not to secure the grpc connection")
+	insecureSkipVerify := fs.Bool("insecureSkipVerify", false, "Whether or not to disable SSL verification")
 	token := fs.String("token", "", "Token to authenticate with control server")
 	namespace := fs.String("namespace", "", "namespace to assign to this managament client")
 
@@ -147,15 +141,7 @@ func (h *mgmtTokenCreate) Run(args []string) int {
 		grpc.WithDefaultCallOptions(grpc.UseCompressor(lz4.Name)),
 	}
 
-	if *insecure {
-		opts = append(opts, grpc.WithInsecure())
-	} else {
-		creds := credentials.NewTLS(&tls.Config{
-			InsecureSkipVerify: true,
-		})
-
-		opts = append(opts, grpc.WithTransportCredentials(creds))
-	}
+	opts = setTransport(opts, insecure, insecureSkipVerify)
 
 	gcc, err := grpc.Dial(*addr, opts...)
 	if err != nil {
@@ -179,6 +165,19 @@ func (h *mgmtTokenCreate) Run(args []string) int {
 	return 0
 }
 
+func setTransport(opts []grpc.DialOption, insecure *bool, insecureSkipVerify *bool) []grpc.DialOption {
+	if *insecure {
+		opts = append(opts, grpc.WithInsecure())
+	} else {
+		creds := credentials.NewTLS(&tls.Config{
+			InsecureSkipVerify: *insecureSkipVerify,
+		})
+
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	}
+	return opts
+}
+
 type llCreate struct{}
 
 func (h *llCreate) Help() string {
@@ -194,6 +193,7 @@ func (h *llCreate) Run(args []string) int {
 
 	addr := fs.String("control-addr", "127.0.0.1:24001", "Address of control server")
 	insecure := fs.Bool("insecure", false, "Whether or not to secure the grpc connection")
+	insecureSkipVerify := fs.Bool("insecureSkipVerify", false, "Whether or not to disable SSL verification")
 	token := fs.String("token", "", "Token to authenticate with control server")
 	gLabel := fs.String("label", "", "global label")
 	acc := fs.String("account", "", "account for the label")
@@ -214,15 +214,7 @@ func (h *llCreate) Run(args []string) int {
 		grpc.WithDefaultCallOptions(grpc.UseCompressor(lz4.Name)),
 	}
 
-	if *insecure {
-		opts = append(opts, grpc.WithInsecure())
-	} else {
-		creds := credentials.NewTLS(&tls.Config{
-			InsecureSkipVerify: true,
-		})
-
-		opts = append(opts, grpc.WithTransportCredentials(creds))
-	}
+	opts = setTransport(opts, insecure, insecureSkipVerify)
 
 	gcc, err := grpc.Dial(*addr, opts...)
 	if err != nil {
@@ -275,6 +267,7 @@ func (h *agentTokenCreate) Run(args []string) int {
 
 	addr := fs.String("control-addr", "127.0.0.1:24001", "Address of control server")
 	insecure := fs.Bool("insecure", false, "Whether or not to secure the grpc connection")
+	insecureSkipVerify := fs.Bool("insecureSkipVerify", false, "Whether or not to disable SSL verification")
 	token := fs.String("token", "", "Token to authenticate with control server")
 	acc := fs.String("account", "", "account for the label")
 
@@ -288,15 +281,7 @@ func (h *agentTokenCreate) Run(args []string) int {
 		grpc.WithDefaultCallOptions(grpc.UseCompressor(lz4.Name)),
 	}
 
-	if *insecure {
-		opts = append(opts, grpc.WithInsecure())
-	} else {
-		creds := credentials.NewTLS(&tls.Config{
-			InsecureSkipVerify: true,
-		})
-
-		opts = append(opts, grpc.WithTransportCredentials(creds))
-	}
+	setTransport(opts, insecure, insecureSkipVerify)
 
 	gcc, err := grpc.Dial(*addr, opts...)
 	if err != nil {

--- a/pkg/control/client.go
+++ b/pkg/control/client.go
@@ -124,7 +124,8 @@ type ClientConfig struct {
 	// Where hub integrates it's handler for the hzn protocol
 	NextProto map[string]func(hs *http.Server, tlsConn *tls.Conn, h http.Handler)
 
-	FilterRoute func(*pb.ServiceRoute) bool
+	FilterRoute        func(*pb.ServiceRoute) bool
+	InsecureSkipVerify bool
 }
 
 func NewClient(ctx context.Context, cfg ClientConfig) (*Client, error) {
@@ -147,9 +148,8 @@ func NewClient(ctx context.Context, cfg ClientConfig) (*Client, error) {
 		if cfg.Insecure {
 			opts = append(opts, grpc.WithInsecure())
 		} else {
-
 			creds := gcreds.NewTLS(&tls.Config{
-				InsecureSkipVerify: true,
+				InsecureSkipVerify: cfg.InsecureSkipVerify,
 			})
 
 			opts = append(opts, grpc.WithTransportCredentials(creds))


### PR DESCRIPTION
Addresses https://github.com/hashicorp/horizon/issues/49.
This commit adds the possibility to define, via a flag, whether
to enable or disable TLS certificate checks.

The default configuration (when `insecure` is false), is actually using TLS but ignoring TLS validity. 
With this change, the user will be able to specify via the `--insecure-skip-verify` flag if he wants to skip the check, but we're switching the default to be secure - exactly as one would expect when `--insecure` is not selected.