### PR TITLE
Rename gorm-debug flag

### DIFF
--- a/internal/testsql/testsql.go
+++ b/internal/testsql/testsql.go
@@ -60,7 +60,7 @@ type nopLogger struct{}
 
 func (_ nopLogger) Print(v ...interface{}) {}
 
-var gormDebug = flag.Bool("hzn-gorm-debug", false, "set to true to have Gorm log all generated SQL.")
+var gormDebug = flag.Bool("hzn-gorm-debug", false, "set to true to have Gorm in Horizon log all generated SQL.")
 
 // TestDBOptions collects options that customize the test databases.
 type TestDBOptions struct {

--- a/internal/testsql/testsql.go
+++ b/internal/testsql/testsql.go
@@ -60,7 +60,7 @@ type nopLogger struct{}
 
 func (_ nopLogger) Print(v ...interface{}) {}
 
-var gormDebug = flag.Bool("gorm-debug", false, "set to true to have Gorm log all generated SQL.")
+var gormDebug = flag.Bool("hzn-gorm-debug", false, "set to true to have Gorm log all generated SQL.")
 
 // TestDBOptions collects options that customize the test databases.
 type TestDBOptions struct {


### PR DESCRIPTION
The `gorm-debug` flag conflicted with another flag in a separate internal package.

This renames that flag to `hzn-gorm-debug`