### PR TITLE
Implement GetCertificate to load cached cert

### DIFF
--- a/cmd/hzn/main.go
+++ b/cmd/hzn/main.go
@@ -463,13 +463,8 @@ func (c *controlServer) Run(args []string) int {
 			}
 		})
 
-		tlsCert, err := tlsmgr.Certificate()
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		var lcfg tls.Config
-		lcfg.Certificates = []tls.Certificate{tlsCert}
+		lcfg.GetCertificate = tlsmgr.GetCertificateFunc()
 
 		hs.TLSConfig = &lcfg
 
@@ -776,7 +771,6 @@ func (c *devServer) Run(args []string) int {
 		WithCredentials(credentials.NewStaticCredentials("hzn", "hzn", "hzn")).
 		WithS3ForcePathStyle(true),
 	)
-
 	if err != nil {
 		log.Fatalf("unable to connect to S3: %v", err)
 	}
@@ -1012,7 +1006,6 @@ func (h *devServer) RunHub(ctx context.Context, token, addr string, sess *sessio
 		Insecure:           true,
 		InsecureSkipVerify: true,
 	})
-
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/tlsmanage/mgr.go
+++ b/pkg/tlsmanage/mgr.go
@@ -185,8 +185,6 @@ func (m *Manager) SetupRoute53(sess *session.Session, zoneId string) error {
 }
 
 func (m *Manager) SetupHubCert(ctx context.Context) error {
-	m.tlsCertMu.Lock()
-	defer m.tlsCertMu.Unlock()
 	domain := m.cfg.Domain
 
 	log.Logger = hclog.FromContext(ctx).StandardLogger(&hclog.StandardLoggerOptions{InferLevels: true})
@@ -219,6 +217,9 @@ func (m *Manager) SetupHubCert(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrapf(err, "attempting to obtain certificate")
 	}
+
+	m.tlsCertMu.Lock()
+	defer m.tlsCertMu.Unlock()
 
 	m.hubCert = cert.Certificate
 	m.hubIssuer = cert.IssuerCertificate


### PR DESCRIPTION
In the past we've had some minor interruptions of service due to certs from LetsEncrypt expiring and our server process not picking up the updated certs that were obtained in a background process. In those instances, remediation typically involved restarting the main process, in which case the new/updated cert was picked up. I _suspect_ this is because we only set the [cert in the `TLSConfig`](https://github.com/hashicorp/horizon/blob/48871c32c4b1117c6c68ebc0708633a6b3f6465e/cmd/hzn/main.go#L471-L474) once at startup. Assuming the background process does renew the cert or obtain a new one, the server never reloads it's TLSConfig and so never picks up the new/updated cert.

In this PR we add a new attribute to the `tlsmanager.Manager` type to cache the cert used for the `TLSConfig`, and wrap any setting or reading of the value with a `RWMutex`. Instead of directly setting the cert in the server's `TLSConfig`, we define a callback method to return the cached value. The background process continues to update the cert material, and now will also update the cached value. 

In a future PR we may update/change how the background process renews the cert, but assuming that part works as designed, this PR should be enough to "fix" our expired cert problem that we've seen periodically. 