### PR TITLE
Minor updates to the dev setup

### DIFF
--- a/cmd/hzn/main.go
+++ b/cmd/hzn/main.go
@@ -152,7 +152,9 @@ func (mr *migrateRunner) Run(args []string) int {
 
 	err = m.Up()
 	if err != nil {
-		log.Fatal(err)
+		if err != migrate.ErrNoChange {
+			log.Fatal(err)
+		}
 	}
 
 	return 0
@@ -776,7 +778,6 @@ func (c *devServer) Run(args []string) int {
 		WithCredentials(credentials.NewStaticCredentials("hzn", "hzn", "hzn")).
 		WithS3ForcePathStyle(true),
 	)
-
 	if err != nil {
 		log.Fatalf("unable to connect to S3: %v", err)
 	}
@@ -1012,7 +1013,6 @@ func (h *devServer) RunHub(ctx context.Context, token, addr string, sess *sessio
 		Insecure:           true,
 		InsecureSkipVerify: true,
 	})
-
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/config/db.go
+++ b/pkg/config/db.go
@@ -18,7 +18,7 @@ var (
 
 var (
 	TestDBUrl = "postgres://localhost/horizon_test?sslmode=disable"
-	DevDBUrl  = "postgres://postgres:postgres@localhost/horizon_dev?sslmode=disable"
+	DevDBUrl  = "postgres://localhost/horizon_dev?sslmode=disable"
 )
 
 func DB() *gorm.DB {

--- a/pkg/config/db.go
+++ b/pkg/config/db.go
@@ -18,7 +18,7 @@ var (
 
 var (
 	TestDBUrl = "postgres://localhost/horizon_test?sslmode=disable"
-	DevDBUrl  = "postgres://localhost/horizon_dev?sslmode=disable"
+	DevDBUrl  = "postgres://postgres:postgres@localhost/horizon_dev?sslmode=disable"
 )
 
 func DB() *gorm.DB {
@@ -50,7 +50,6 @@ func DB() *gorm.DB {
 
 	if db == nil {
 		panic("no database configured")
-
 	}
 	return db
 }


### PR DESCRIPTION
This PR makes 2 minor changes to the dev setup. 

In one change, update the `DevDBUrl` url to include the username and password. When I ran `make dev-setup`, I would get errors because `psql` user `clint` didn't exist.

In the other change, running `make dev-setup` multiple times can fail after the first, because we would return an error if there were no migration changes. Now we only return error if it's an error and not a _no-migration-error_.